### PR TITLE
refactor: migrate read methods to reactive streams

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,12 +35,14 @@ jacoco {
 
 dependencies {
     implementation("org.slf4j:slf4j-api:2.0.17")
+    implementation("io.projectreactor:reactor-core:3.7.6")
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.13.4")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("org.mockito:mockito-core:5.8.0")
     testImplementation("org.mockito:mockito-junit-jupiter:5.19.0")
     testImplementation("ch.qos.logback:logback-classic:1.5.18")
+    testImplementation("io.projectreactor:reactor-test:3.6.10")
 }
 
 tasks.test {

--- a/src/main/java/com/github/lukaszbudnik/wal/WriteAheadLog.java
+++ b/src/main/java/com/github/lukaszbudnik/wal/WriteAheadLog.java
@@ -3,6 +3,7 @@ package com.github.lukaszbudnik.wal;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.List;
+import org.reactivestreams.Publisher;
 
 /**
  * Interface defining the contract for Write Ahead Log implementations.
@@ -43,39 +44,35 @@ public interface WriteAheadLog extends AutoCloseable {
    * Read entries starting from the given sequence number
    *
    * @param fromSequenceNumber the starting sequence number (inclusive)
-   * @return list of entries
-   * @throws WALException if the operation fails
+   * @return publisher of entries
    */
-  List<WALEntry> readFrom(long fromSequenceNumber) throws WALException;
+  Publisher<WALEntry> readFrom(long fromSequenceNumber);
 
   /**
    * Read entries in a sequence number range
    *
    * @param fromSequenceNumber the starting sequence number (inclusive)
    * @param toSequenceNumber the ending sequence number (inclusive)
-   * @return list of entries
-   * @throws WALException if the operation fails
+   * @return publisher of entries
    */
-  List<WALEntry> readRange(long fromSequenceNumber, long toSequenceNumber) throws WALException;
+  Publisher<WALEntry> readRange(long fromSequenceNumber, long toSequenceNumber);
 
   /**
    * Read entries starting from the given timestamp
    *
    * @param fromTimestamp the starting timestamp (inclusive)
-   * @return list of entries with timestamps >= fromTimestamp
-   * @throws WALException if the operation fails
+   * @return publisher of entries with timestamps >= fromTimestamp
    */
-  List<WALEntry> readFrom(Instant fromTimestamp) throws WALException;
+  Publisher<WALEntry> readFrom(Instant fromTimestamp);
 
   /**
    * Read entries in a timestamp range
    *
    * @param fromTimestamp the starting timestamp (inclusive)
    * @param toTimestamp the ending timestamp (inclusive)
-   * @return list of entries with timestamps in the specified range
-   * @throws WALException if the operation fails
+   * @return publisher of entries with timestamps in the specified range
    */
-  List<WALEntry> readRange(Instant fromTimestamp, Instant toTimestamp) throws WALException;
+  Publisher<WALEntry> readRange(Instant fromTimestamp, Instant toTimestamp);
 
   /**
    * Get the current sequence number (last written entry)

--- a/src/test/java/com/github/lukaszbudnik/wal/ThreadSafetyIntegrationTest.java
+++ b/src/test/java/com/github/lukaszbudnik/wal/ThreadSafetyIntegrationTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import reactor.core.publisher.Flux;
 
 /** Integration test to demonstrate that the thread safety issues have been fixed. */
 class ThreadSafetyIntegrationTest {
@@ -92,7 +93,7 @@ class ThreadSafetyIntegrationTest {
     }
 
     // Verify all entries are persisted correctly
-    List<WALEntry> persistedEntries = wal.readFrom(0L);
+    List<WALEntry> persistedEntries = Flux.from(wal.readFrom(0L)).collectList().block();
     assertEquals(numThreads * entriesPerThread, persistedEntries.size());
 
     // Verify sequence numbers in persisted entries are also consecutive
@@ -160,7 +161,7 @@ class ThreadSafetyIntegrationTest {
     wal.sync();
 
     // Verify persistence
-    List<WALEntry> persistedEntries = wal.readFrom(0L);
+    List<WALEntry> persistedEntries = Flux.from(wal.readFrom(0L)).collectList().block();
     assertEquals(numThreads * batchSize, persistedEntries.size());
   }
 
@@ -228,7 +229,7 @@ class ThreadSafetyIntegrationTest {
     wal.sync();
 
     // Verify total count and sequence integrity
-    List<WALEntry> allEntries = wal.readFrom(0L);
+    List<WALEntry> allEntries = Flux.from(wal.readFrom(0L)).collectList().block();
     assertEquals(totalExpected, allEntries.size());
 
     // Verify consecutive sequence numbers


### PR DESCRIPTION
refactor: migrate read methods to reactive streams with proper error handling

- Remove throws WALException from all read*() methods in WriteAheadLog interface
- Update FileBasedWAL to use Publisher<WALEntry> return types for streaming
- Implement reactive streams error handling via sink.error() instead of exceptions
- Fix readRange(Instant, Instant) and remove unnecessary sorting since data on disk is already ordered by sequence
- Add emitEntriesFromFileBySequence/emitEntriesFromFileByTimestamp streaming methods
- Update CRC32ValidationTest to handle ReactiveException wrapping with Exceptions.unwrap()
- Update FileBasedWALTest error assertions for reactive streams
- Remove old helper methods that collected entries in Lists

Enables true reactive streaming, prevents OOME on large ranges, and provides composable error handling.