### PR TITLE
Fix/page boundary read bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,36 @@ Pintor is lightweight with minimal external dependencies, relying only on:
 - `long size()`: Get entry count.
 - `boolean isEmpty()`: Check if WAL is empty.
 
+### WALMetrics
+
+WALMetrics provides comprehensive operational statistics for monitoring and performance analysis:
+
+```java
+WALMetrics metrics = wal.getMetrics();
+
+// Write metrics
+long entriesWritten = metrics.getEntriesWritten();
+long bytesWritten = metrics.getBytesWritten();
+long pagesWritten = metrics.getPagesWritten();
+long filesCreated = metrics.getFilesCreated();
+
+// Read metrics
+long entriesRead = metrics.getEntriesRead();
+long pagesRead = metrics.getPagesRead();
+long rangeQueries = metrics.getRangeQueries();
+
+// I/O efficiency metrics
+long filesScanned = metrics.getFilesScanned();
+long pagesScanned = metrics.getPagesScanned();
+```
+
+**Key Metrics:**
+- **Write Operations**: Track entries written, total bytes, pages written, and file creation
+- **Read Operations**: Monitor entries read, pages read, and query patterns
+- **I/O Efficiency**: Measure files and pages scanned for performance optimization
+- **Thread-Safe**: All counters use atomic operations for concurrent access
+- **Cumulative**: Metrics accumulate across the lifetime of the WAL instance
+
 ### Configuration
 
 ```java

--- a/src/main/java/com/github/lukaszbudnik/wal/FileBasedWAL.java
+++ b/src/main/java/com/github/lukaszbudnik/wal/FileBasedWAL.java
@@ -39,6 +39,7 @@ public class FileBasedWAL implements WriteAheadLog {
   private final int maxFileSize;
   private final ReadWriteLock lock = new ReentrantReadWriteLock();
   private final Map<Integer, Path> walFiles = new TreeMap<>();
+  private final WALMetrics metrics = new WALMetrics();
 
   private long currentSequenceNumber = -1;
   private int currentFileIndex = 0;
@@ -195,6 +196,10 @@ public class FileBasedWAL implements WriteAheadLog {
     long fileLength = currentFile.length();
     currentFile.seek(fileLength); // Position at end for appending
 
+    if (isNewFile) {
+      metrics.incrementFilesCreated();
+    }
+
     logger.debug(
         "Opened WAL file: {} (index={}, length={} bytes, isNew={})",
         currentFilePath.getFileName(),
@@ -319,6 +324,10 @@ public class FileBasedWAL implements WriteAheadLog {
     }
 
     logger.debug("Entry written: seq={}, totalSize={} bytes", entry.getSequenceNumber(), entrySize);
+
+    // Update metrics
+    metrics.incrementEntriesWritten();
+    metrics.incrementBytesWritten(entrySize);
   }
 
   /** Write entry that fits in current page. */
@@ -447,6 +456,9 @@ public class FileBasedWAL implements WriteAheadLog {
         filePositionAfter,
         currentFile.length());
 
+    // Update metrics
+    metrics.incrementPagesWritten();
+
     // Check if we need to rotate file (only if not in middle of spanning entry)
     if (continuationFlags == WALPageHeader.NO_CONTINUATION
         || continuationFlags == WALPageHeader.LAST_PART) {
@@ -537,6 +549,7 @@ public class FileBasedWAL implements WriteAheadLog {
     }
 
     logger.debug("Reading entries in sequence range: {}-{}", fromSequenceNumber, toSequenceNumber);
+    metrics.incrementRangeQueries();
 
     return Flux.create(
         sink -> {
@@ -559,6 +572,7 @@ public class FileBasedWAL implements WriteAheadLog {
                 overlappingFiles.add(walFile);
                 logger.debug("File {} overlaps with requested range", walFile.getFileName());
               }
+              metrics.incrementFilesScanned();
             }
 
             logger.debug("Found {} overlapping files to process", overlappingFiles.size());
@@ -639,6 +653,7 @@ public class FileBasedWAL implements WriteAheadLog {
 
         try {
           WALPageHeader header = WALPageHeader.deserialize(headerData);
+          metrics.incrementPagesScanned();
 
           // Skip non-overlapping pages (but not if we're in middle of spanning entry)
           if (spanningEntryData == null
@@ -664,6 +679,7 @@ public class FileBasedWAL implements WriteAheadLog {
               file.seek(currentPos + WALPageHeader.HEADER_SIZE);
               file.readFully(pageData);
               spanningEntryData.write(pageData);
+              metrics.incrementPagesRead();
 
               if (header.isLastPart()) {
                 // Complete spanning entry
@@ -672,6 +688,7 @@ public class FileBasedWAL implements WriteAheadLog {
 
                 if (entry.getSequenceNumber() >= fromSeq && entry.getSequenceNumber() <= toSeq) {
                   sink.next(entry);
+                  metrics.incrementEntriesRead();
                 }
 
                 spanningEntryData = null;
@@ -682,6 +699,7 @@ public class FileBasedWAL implements WriteAheadLog {
             // Handle regular page with complete entries
             emitEntriesFromPage(
                 sink, file, currentPos + WALPageHeader.HEADER_SIZE, dataSize, fromSeq, toSeq);
+            metrics.incrementPagesRead();
           }
 
         } catch (WALException e) {
@@ -737,6 +755,7 @@ public class FileBasedWAL implements WriteAheadLog {
         // Filter by sequence range
         if (entry.getSequenceNumber() >= fromSeq && entry.getSequenceNumber() <= toSeq) {
           sink.next(entry);
+          metrics.incrementEntriesRead();
         }
       } catch (WALException e) {
         // Let CRC32 validation errors propagate, but log other deserialization issues
@@ -767,6 +786,7 @@ public class FileBasedWAL implements WriteAheadLog {
     }
 
     logger.debug("Reading entries in timestamp range: {} to {}", fromTimestamp, toTimestamp);
+    metrics.incrementRangeQueries();
 
     return Flux.create(
         sink -> {
@@ -789,6 +809,7 @@ public class FileBasedWAL implements WriteAheadLog {
                 overlappingFiles.add(walFile);
                 logger.debug("File {} overlaps with timestamp range", walFile.getFileName());
               }
+              metrics.incrementFilesScanned();
             }
 
             logger.debug("Found {} overlapping files for timestamp range", overlappingFiles.size());
@@ -875,6 +896,7 @@ public class FileBasedWAL implements WriteAheadLog {
 
         try {
           WALPageHeader header = WALPageHeader.deserialize(headerData);
+          metrics.incrementPagesScanned();
 
           // Skip non-overlapping pages (but not if we're in middle of spanning entry)
           if (spanningEntryData == null
@@ -901,6 +923,7 @@ public class FileBasedWAL implements WriteAheadLog {
               file.seek(currentPos + WALPageHeader.HEADER_SIZE);
               file.readFully(pageData);
               spanningEntryData.write(pageData);
+              metrics.incrementPagesRead();
 
               if (header.isLastPart()) {
                 // Complete spanning entry
@@ -910,6 +933,7 @@ public class FileBasedWAL implements WriteAheadLog {
                 // Filter by timestamp range
                 if (!entry.getTimestamp().isBefore(fromTs) && !entry.getTimestamp().isAfter(toTs)) {
                   sink.next(entry);
+                  metrics.incrementEntriesRead();
                 }
 
                 spanningEntryData = null;
@@ -920,6 +944,7 @@ public class FileBasedWAL implements WriteAheadLog {
             // Handle regular page with complete entries
             emitEntriesFromPageByTimestamp(
                 sink, file, currentPos + WALPageHeader.HEADER_SIZE, dataSize, fromTs, toTs);
+            metrics.incrementPagesRead();
           }
 
         } catch (WALException e) {
@@ -973,6 +998,7 @@ public class FileBasedWAL implements WriteAheadLog {
         // Filter by timestamp range
         if (!entry.getTimestamp().isBefore(fromTs) && !entry.getTimestamp().isAfter(toTs)) {
           sink.next(entry);
+          metrics.incrementEntriesRead();
         }
       } catch (WALException e) {
         // Let CRC32 validation errors propagate, but log other deserialization issues
@@ -1077,6 +1103,11 @@ public class FileBasedWAL implements WriteAheadLog {
   @Override
   public boolean isEmpty() {
     return currentSequenceNumber == -1;
+  }
+
+  @Override
+  public WALMetrics getMetrics() {
+    return metrics;
   }
 
   @Override

--- a/src/main/java/com/github/lukaszbudnik/wal/WALMetrics.java
+++ b/src/main/java/com/github/lukaszbudnik/wal/WALMetrics.java
@@ -1,0 +1,162 @@
+package com.github.lukaszbudnik.wal;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Thread-safe metrics tracking for Write Ahead Log operations.
+ *
+ * <p>Provides comprehensive operational statistics including write operations, read operations, and
+ * I/O efficiency metrics. All counters are cumulative and thread-safe using atomic operations.
+ */
+public class WALMetrics {
+
+  // Write metrics
+  private final AtomicLong entriesWritten = new AtomicLong();
+  private final AtomicLong bytesWritten = new AtomicLong();
+  private final AtomicLong pagesWritten = new AtomicLong();
+  private final AtomicLong filesCreated = new AtomicLong();
+
+  // Read metrics
+  private final AtomicLong entriesRead = new AtomicLong();
+  private final AtomicLong pagesRead = new AtomicLong();
+  private final AtomicLong rangeQueries = new AtomicLong();
+
+  // I/O efficiency metrics
+  private final AtomicLong filesScanned = new AtomicLong();
+  private final AtomicLong pagesScanned = new AtomicLong();
+
+  /**
+   * Get the total number of entries written to the WAL.
+   *
+   * @return cumulative count of entries written
+   */
+  public long getEntriesWritten() {
+    return entriesWritten.get();
+  }
+
+  /**
+   * Get the total number of bytes written to the WAL.
+   *
+   * @return cumulative bytes written
+   */
+  public long getBytesWritten() {
+    return bytesWritten.get();
+  }
+
+  /**
+   * Get the total number of pages written to the WAL.
+   *
+   * @return cumulative count of pages written
+   */
+  public long getPagesWritten() {
+    return pagesWritten.get();
+  }
+
+  /**
+   * Get the total number of WAL files created.
+   *
+   * @return cumulative count of files created
+   */
+  public long getFilesCreated() {
+    return filesCreated.get();
+  }
+
+  /**
+   * Get the total number of entries read from the WAL.
+   *
+   * @return cumulative count of entries read
+   */
+  public long getEntriesRead() {
+    return entriesRead.get();
+  }
+
+  /**
+   * Get the total number of pages read from the WAL.
+   *
+   * @return cumulative count of pages read
+   */
+  public long getPagesRead() {
+    return pagesRead.get();
+  }
+
+  /**
+   * Get the total number of range queries performed.
+   *
+   * @return cumulative count of range queries
+   */
+  public long getRangeQueries() {
+    return rangeQueries.get();
+  }
+
+  /**
+   * Get the total number of WAL files scanned during read operations.
+   *
+   * @return cumulative count of files scanned
+   */
+  public long getFilesScanned() {
+    return filesScanned.get();
+  }
+
+  /**
+   * Get the total number of pages scanned during read operations.
+   *
+   * @return cumulative count of pages scanned
+   */
+  public long getPagesScanned() {
+    return pagesScanned.get();
+  }
+
+  // Package-private methods for internal metric updates
+
+  void incrementEntriesWritten() {
+    entriesWritten.incrementAndGet();
+  }
+
+  void incrementEntriesWritten(long count) {
+    entriesWritten.addAndGet(count);
+  }
+
+  void incrementBytesWritten(long bytes) {
+    bytesWritten.addAndGet(bytes);
+  }
+
+  void incrementPagesWritten() {
+    pagesWritten.incrementAndGet();
+  }
+
+  void incrementFilesCreated() {
+    filesCreated.incrementAndGet();
+  }
+
+  void incrementEntriesRead() {
+    entriesRead.incrementAndGet();
+  }
+
+  void incrementEntriesRead(long count) {
+    entriesRead.addAndGet(count);
+  }
+
+  void incrementPagesRead() {
+    pagesRead.incrementAndGet();
+  }
+
+  void incrementRangeQueries() {
+    rangeQueries.incrementAndGet();
+  }
+
+  void incrementFilesScanned() {
+    filesScanned.incrementAndGet();
+  }
+
+  void incrementFilesScanned(long count) {
+    filesScanned.addAndGet(count);
+  }
+
+  void incrementPagesScanned() {
+    pagesScanned.incrementAndGet();
+  }
+
+  void incrementPagesScanned(long count) {
+    pagesScanned.addAndGet(count);
+  }
+}

--- a/src/main/java/com/github/lukaszbudnik/wal/WriteAheadLog.java
+++ b/src/main/java/com/github/lukaszbudnik/wal/WriteAheadLog.java
@@ -110,4 +110,11 @@ public interface WriteAheadLog extends AutoCloseable {
    * @return true if empty, false otherwise
    */
   boolean isEmpty();
+
+  /**
+   * Get operational metrics for monitoring and performance analysis
+   *
+   * @return WAL metrics instance with cumulative statistics
+   */
+  WALMetrics getMetrics();
 }

--- a/src/test/java/com/github/lukaszbudnik/wal/WALMetricsTest.java
+++ b/src/test/java/com/github/lukaszbudnik/wal/WALMetricsTest.java
@@ -1,0 +1,197 @@
+package com.github.lukaszbudnik.wal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import reactor.core.publisher.Flux;
+
+class WALMetricsTest {
+
+  @TempDir Path tempDir;
+  private FileBasedWAL wal;
+
+  @BeforeEach
+  void setUp() throws WALException {
+    wal = new FileBasedWAL(tempDir);
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    if (wal != null) {
+      wal.close();
+    }
+  }
+
+  @Test
+  void testInitialMetrics() throws WALException {
+    WALMetrics metrics = wal.getMetrics();
+
+    assertEquals(0, metrics.getEntriesWritten());
+    assertEquals(0, metrics.getBytesWritten());
+    assertEquals(0, metrics.getPagesWritten());
+    assertEquals(0, metrics.getEntriesRead());
+    assertEquals(0, metrics.getPagesRead());
+    assertEquals(0, metrics.getFilesScanned());
+    assertEquals(0, metrics.getPagesScanned());
+    assertEquals(0, metrics.getRangeQueries());
+    assertEquals(1, metrics.getFilesCreated()); // First file created during initialization
+  }
+
+  @Test
+  void testSingleEntryWriteMetrics() throws WALException {
+    WALMetrics metrics = wal.getMetrics();
+
+    String data = "test entry";
+    ByteBuffer buffer = ByteBuffer.wrap(data.getBytes());
+    wal.createAndAppend(buffer);
+    wal.sync(); // Force page flush
+
+    assertEquals(1, metrics.getEntriesWritten());
+    assertTrue(metrics.getBytesWritten() > 0);
+    assertTrue(metrics.getPagesWritten() > 0);
+    assertEquals(1, metrics.getFilesCreated()); // Only initial file, no rotation
+  }
+
+  @Test
+  void testBatchWriteMetrics() throws WALException {
+    WALMetrics metrics = wal.getMetrics();
+
+    List<ByteBuffer> batch =
+        Arrays.asList(
+            ByteBuffer.wrap("entry1".getBytes()),
+            ByteBuffer.wrap("entry2".getBytes()),
+            ByteBuffer.wrap("entry3".getBytes()));
+
+    wal.createAndAppendBatch(batch);
+
+    assertEquals(3, metrics.getEntriesWritten());
+    assertTrue(metrics.getBytesWritten() > 0);
+  }
+
+  @Test
+  void testReadMetrics() throws WALException {
+    // Write some entries first
+    for (int i = 0; i < 10; i++) {
+      wal.createAndAppend(ByteBuffer.wrap(("entry" + i).getBytes()));
+    }
+
+    WALMetrics metrics = wal.getMetrics();
+    long entriesReadBefore = metrics.getEntriesRead();
+    long pagesReadBefore = metrics.getPagesRead();
+    long rangeQueriesBefore = metrics.getRangeQueries();
+
+    // Read all entries
+    List<WALEntry> entries = Flux.from(wal.readFrom(0L)).collectList().block();
+
+    assertEquals(10, metrics.getEntriesRead() - entriesReadBefore);
+    assertTrue(metrics.getPagesRead() > pagesReadBefore);
+    assertEquals(1, metrics.getRangeQueries() - rangeQueriesBefore);
+  }
+
+  @Test
+  void testRangeQueryMetrics() throws WALException {
+    // Write entries
+    for (int i = 0; i < 20; i++) {
+      wal.createAndAppend(ByteBuffer.wrap(("entry" + i).getBytes()));
+    }
+
+    WALMetrics metrics = wal.getMetrics();
+    long entriesReadBefore = metrics.getEntriesRead();
+    long rangeQueriesBefore = metrics.getRangeQueries();
+
+    // Read range 5-15
+    List<WALEntry> entries = Flux.from(wal.readRange(5L, 15L)).collectList().block();
+
+    assertEquals(11, metrics.getEntriesRead() - entriesReadBefore); // 5-15 inclusive
+    assertEquals(1, metrics.getRangeQueries() - rangeQueriesBefore);
+  }
+
+  @Test
+  void testFileCreationMetrics() throws Exception {
+    // Use smaller file size to force rotation
+    wal.close();
+    wal = new FileBasedWAL(tempDir, 8192); // 8KB files
+
+    WALMetrics metrics = wal.getMetrics();
+    long initialFiles = metrics.getFilesCreated();
+
+    // Create entries large enough to trigger file rotation
+    for (int i = 0; i < 50; i++) {
+      String largeData = "entry" + i + "_" + "x".repeat(200); // ~200 bytes per entry
+      wal.createAndAppend(ByteBuffer.wrap(largeData.getBytes()));
+
+      if (i % 10 == 0) {
+        wal.sync(); // Force file rotation check
+      }
+    }
+
+    assertTrue(metrics.getFilesCreated() > initialFiles, "Should create additional files");
+    assertEquals(50, metrics.getEntriesWritten());
+  }
+
+  @Test
+  void testMetricsAccumulation() throws WALException {
+    WALMetrics metrics = wal.getMetrics();
+
+    // Multiple write operations
+    wal.createAndAppend(ByteBuffer.wrap("entry1".getBytes()));
+    wal.createAndAppend(ByteBuffer.wrap("entry2".getBytes()));
+
+    assertEquals(2, metrics.getEntriesWritten());
+
+    // Multiple read operations
+    Flux.from(wal.readFrom(0L)).collectList().block();
+    Flux.from(wal.readRange(0L, 1L)).collectList().block();
+
+    assertEquals(4, metrics.getEntriesRead()); // 2 + 2
+    assertEquals(2, metrics.getRangeQueries());
+  }
+
+  @Test
+  void testBytesWrittenAccuracy() throws WALException {
+    WALMetrics metrics = wal.getMetrics();
+
+    String data1 = "small";
+    String data2 = "much_larger_entry_with_more_data";
+
+    long bytesBefore = metrics.getBytesWritten();
+
+    wal.createAndAppend(ByteBuffer.wrap(data1.getBytes()));
+    long bytesAfterFirst = metrics.getBytesWritten();
+
+    wal.createAndAppend(ByteBuffer.wrap(data2.getBytes()));
+    long bytesAfterSecond = metrics.getBytesWritten();
+
+    assertTrue(bytesAfterFirst > bytesBefore);
+    assertTrue(bytesAfterSecond > bytesAfterFirst);
+    assertTrue((bytesAfterSecond - bytesAfterFirst) > (bytesAfterFirst - bytesBefore));
+  }
+
+  @Test
+  void testPageMetrics() throws WALException {
+    WALMetrics metrics = wal.getMetrics();
+
+    // Write entries to trigger page writes
+    for (int i = 0; i < 5; i++) {
+      wal.createAndAppend(ByteBuffer.wrap(("entry" + i).getBytes()));
+    }
+    wal.sync(); // Force page flush
+
+    long pagesWritten = metrics.getPagesWritten();
+    assertTrue(pagesWritten > 0, "Should have written pages");
+
+    // Read entries to trigger page reads
+    long pagesReadBefore = metrics.getPagesRead();
+    Flux.from(wal.readFrom(0L)).collectList().block();
+
+    long pagesReadAfter = metrics.getPagesRead();
+    assertTrue(pagesReadAfter > pagesReadBefore, "Should have read pages");
+  }
+}


### PR DESCRIPTION
Fix critical durability bug in page boundary reading logic

- Remove incorrect +4 CRC32 validation in emitEntriesFromPage methods
- CRC32 is already included in ENTRY_HEADER_SIZE, was being double-counted
- Bug caused entries that exactly filled page data section to be unreadable
- Affects both sequence-based and timestamp-based reading methods
- Add comprehensive tests for exact page size and page flushing edge cases

Fixes data loss issue where entries were written correctly but couldn't be read back when they exactly filled the 4052-byte page data section boundary.